### PR TITLE
Fix for issue #3 - Bad Practice for hashing passwords

### DIFF
--- a/Sources/App/Models/User.swift
+++ b/Sources/App/Models/User.swift
@@ -110,7 +110,7 @@ extension User: PasswordAuthenticatable {
 
 // store private variable since storage in extensions
 // is not yet allowed in Swift
-private var _userPasswordVerifier: PasswordVerifier? = nil
+private var _userPasswordVerifier: PasswordVerifier? = BCryptHasher()
 
 // MARK: Request
 

--- a/Sources/App/Routes.swift
+++ b/Sources/App/Routes.swift
@@ -55,7 +55,7 @@ extension Droplet {
             }
 
             // hash the password and set it on the user
-            user.password = try self.hash.make(password.makeBytes()).makeString()
+            user.password = try BCryptHasher().make(password.makeBytes()).makeString()
 
             // save and return the new user
             try user.save()


### PR DESCRIPTION
- Changed `Routes.swift` to use `BCryptHasher` for password hashing instead of relying on `Droplet.hash` which uses sha256.
- Changed `User.swift` to return an instance of `BCryptHasher` for its `passwordVerifier` instead of returning `nil`.

Fixes issue #3 
